### PR TITLE
Implement train/valid/test split and k-fold cv

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,33 +10,47 @@ computational chemistry.
 ```python
 >>> import mxnet as mx
 >>> import yamlchem as yc
->>> batch_size, n_epochs, valid_ratio, lr, verbose = 32, 40, 0.1, 0.01, 10
->>> dataset = yc.data.sets.ESOLDataset(force_reload=True)
->>> train_data, valid_data = yc.data.splitter.train_test_split(
-...     dataset, valid_ratio, True, False)
+>>> batch_size, n_epochs, learning_rate = 32, 40, 0.01
+>>> valid_ratio, test_ratio, feature_name = 0.1, 0.1, 'h'
+>>> data = yc.data.sets.ESOLDataset(force_reload=True)
+>>> train_data, valid_data, test_data = yc.data.splitter.train_valid_test_split(
+...     data, valid_ratio=valid_ratio, test_ratio=test_ratio,
+...     shuffle=True, use_same_dataset_class=False)
 >>> batchify_fn = yc.data.loader.BatchifyGraph(labeled=True, masked=False)
->>> dataloader = mx.gluon.data.DataLoader(
+>>> train_loader = mx.gluon.data.DataLoader(
 ...     train_data, batch_size=batch_size, last_batch='rollover',
 ...     shuffle=True, batchify_fn=batchify_fn)
->>> valid_dataloader = mx.gluon.data.DataLoader(
-...     valid_data, batch_size=batch_size, batchify_fn=batchify_fn)
+>>> valid_loader = mx.gluon.data.DataLoader(
+...     valid_data, batch_size=len(valid_data), batchify_fn=batchify_fn)
+>>> test_loader = mx.gluon.data.DataLoader(
+...     test_data, batch_size=len(test_data), batchify_fn=batchify_fn)
 >>> loss_fn = mx.gluon.loss.L2Loss(prefix='MSE')
->>> lr_scheduler = mx.lr_scheduler.FactorScheduler(len(dataloader), 0.9, lr)
+>>> lr_scheduler = mx.lr_scheduler.FactorScheduler(
+...     len(train_loader), factor=0.95, stop_factor_lr=5e-4,
+...     base_lr=learning_rate)
 >>> optimizer = mx.optimizer.Adam(
-...     learning_rate=lr, lr_scheduler=lr_scheduler)
+...     learning_rate=learning_rate, lr_scheduler=lr_scheduler)
 >>> metric = mx.metric.RMSE(name='RMSE')
 >>> gcn = yc.nn.block.graph.GCN(yc.feature.graph.N_DEFAULT_ATOM_FEATURES)
 >>> readout = yc.nn.block.graph.WeightSum()
 >>> predictor = yc.nn.block.graph.NodeGNNPredictor(gcn, readout, 1)
 >>> yc.nn.model.train_gnn_predictor(
-...     gnn=predictor, feature_name='h', dataloader=dataloader,
+...     gnn=predictor, feature_name=feature_name, dataloader=train_loader,
 ...     loss_fn=loss_fn, n_epochs=n_epochs, optimizer=optimizer,
-...     metric=metric, valid_dataloader=valid_dataloader, verbose=verbose)
+...     metric=metric, valid_dataloader=valid_loader, verbose=10)
 Using backend: mxnet
 Epoch: 10, Time: 0:00:02, T.MSE: 0.409, V.MSE: 0.313, T.RMSE: 0.918, V.RMSE: 0.706
 Epoch: 20, Time: 0:00:02, T.MSE: 0.239, V.MSE: 0.191, T.RMSE: 0.656, V.RMSE: 0.627
 Epoch: 30, Time: 0:00:02, T.MSE: 0.198, V.MSE: 0.280, T.RMSE: 0.606, V.RMSE: 0.732
 Epoch: 40, Time: 0:00:02, T.MSE: 0.126, V.MSE: 0.156, T.RMSE: 0.457, V.RMSE: 0.627
+>>> test_batch = next(iter(test_loader))
+>>> predictions = predictor(
+...     test_batch.graph, test_batch.graph.ndata[feature_name])
+>>> metric.reset()
+>>> metric.update(
+...     preds=predictions, labels=test_batch.label.reshape_like(predictions))
+>>> print(f'Test {metric.name}: {metric.get()[1]:.3f}')
+Test RMSE: 0.460
 ```
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -10,30 +10,33 @@ computational chemistry.
 ```python
 >>> import mxnet as mx
 >>> import yamlchem as yc
+>>> batch_size, n_epochs, valid_ratio, lr, verbose = 32, 40, 0.1, 0.01, 10
 >>> dataset = yc.data.sets.ESOLDataset(force_reload=True)
+>>> train_data, valid_data = yc.data.splitter.train_test_split(
+...     dataset, valid_ratio, True, False)
 >>> batchify_fn = yc.data.loader.BatchifyGraph(labeled=True, masked=False)
 >>> dataloader = mx.gluon.data.DataLoader(
-...     dataset, batch_size=32, last_batch='rollover', shuffle=True,
-...     batchify_fn=batchify_fn)
+...     train_data, batch_size=batch_size, last_batch='rollover',
+...     shuffle=True, batchify_fn=batchify_fn)
+>>> valid_dataloader = mx.gluon.data.DataLoader(
+...     valid_data, batch_size=batch_size, batchify_fn=batchify_fn)
 >>> loss_fn = mx.gluon.loss.L2Loss(prefix='MSE')
->>> lr_scheduler = mx.lr_scheduler.FactorScheduler(len(dataloader), 0.9, 0.01)
->>> optimizer = mx.optimizer.Adam(learning_rate=0.01, lr_scheduler=lr_scheduler)
+>>> lr_scheduler = mx.lr_scheduler.FactorScheduler(len(dataloader), 0.9, lr)
+>>> optimizer = mx.optimizer.Adam(
+...     learning_rate=lr, lr_scheduler=lr_scheduler)
 >>> metric = mx.metric.RMSE(name='RMSE')
->>> gcn = yc.nn.block.graph.GCN(
-...     yc.feature.graph.N_DEFAULT_ATOM_FEATURES, hidden_dim=64, n_layers=2,
-...     activation='relu', norm='both', dropout=0.2, batchnorm=True, residual=True)
+>>> gcn = yc.nn.block.graph.GCN(yc.feature.graph.N_DEFAULT_ATOM_FEATURES)
 >>> readout = yc.nn.block.graph.WeightSum()
 >>> predictor = yc.nn.block.graph.NodeGNNPredictor(gcn, readout, 1)
 >>> yc.nn.model.train_gnn_predictor(
-...     gnn=predictor, feature_name='h', dataloader=dataloader, loss_fn=loss_fn,
-...     n_epochs=50, optimizer=optimizer, metric=metric, validation_fraction=0.2,
-...     verbose=10)
+...     gnn=predictor, feature_name='h', dataloader=dataloader,
+...     loss_fn=loss_fn, n_epochs=n_epochs, optimizer=optimizer,
+...     metric=metric, valid_dataloader=valid_dataloader, verbose=verbose)
 Using backend: mxnet
 Epoch: 10, Time: 0:00:02, T.MSE: 0.409, V.MSE: 0.313, T.RMSE: 0.918, V.RMSE: 0.706
 Epoch: 20, Time: 0:00:02, T.MSE: 0.239, V.MSE: 0.191, T.RMSE: 0.656, V.RMSE: 0.627
 Epoch: 30, Time: 0:00:02, T.MSE: 0.198, V.MSE: 0.280, T.RMSE: 0.606, V.RMSE: 0.732
 Epoch: 40, Time: 0:00:02, T.MSE: 0.126, V.MSE: 0.156, T.RMSE: 0.457, V.RMSE: 0.627
-Epoch: 50, Time: 0:00:02, T.MSE: 0.129, V.MSE: 0.098, T.RMSE: 0.509, V.RMSE: 0.406
 ```
 
 ## Installation

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -11,6 +11,7 @@ import numpy as np
 from yamlchem.data.loader import batchify_labeled_masked_graphs
 from yamlchem.data.sets import ESOLDataset, Tox21Dataset
 from yamlchem.feature.graph import N_DEFAULT_ATOM_FEATURES
+from yamlchem.data.splitter import train_test_split, train_valid_test_split
 
 
 def test_esol_dataset():
@@ -74,3 +75,16 @@ def test_labeled_graph_data_loader():
   assert batch_graphs.number_of_edges() == graphs.number_of_edges()
   assert batch_labels.shape == labels.shape
   assert batch_masks.shape == masks.shape
+
+
+def test_splitter():
+  data = mx.gluon.data.ArrayDataset(list(range(10)))
+  train_data, valid_data = train_test_split(data, 0.2, False)
+  assert list(train_data) == list(range(8))
+  assert list(valid_data) == [8, 9]
+
+  train_data, valid_data = train_test_split(data, 0.2, True)
+  assert not (set(train_data) & set(valid_data))
+
+  train_data, valid_data, test_data = train_valid_test_split(data, 0.2, 0.1)
+  assert (len(train_data), len(valid_data), len(test_data)) == (7, 2, 1)

--- a/yamlchem/data/__init__.py
+++ b/yamlchem/data/__init__.py
@@ -5,9 +5,11 @@ data loaders (mini-batch samplers).
 __all__ = (
     'loader',
     'sets',
+    'splitter',
 )
 
 from . import (
     loader,
     sets,
+    splitter,
 )

--- a/yamlchem/data/splitter.py
+++ b/yamlchem/data/splitter.py
@@ -1,0 +1,199 @@
+"""The :mod:`yamlchem.data.splitter` module implements utilities to split the
+data into training and validation/test data.
+
+Classes:
+  KFoldSplitter: K-fold cross-validation split.
+
+Functions:
+  train_test_split
+  train_valid_test_split
+"""
+
+__all__ = (
+    'KFoldSplitter',
+    'train_test_split',
+    'train_valid_test_split',
+)
+
+import array
+import itertools
+import math
+import random
+from typing import Generator, Tuple
+
+from mxnet.gluon.data import ArrayDataset, Dataset
+
+
+def train_test_split(
+    dataset: Dataset,
+    test_ratio: float = 0.1,
+    shuffle: bool = True,
+    use_same_dataset_class: bool = True,
+) -> Tuple[Dataset, Dataset]:
+  """Split `dataset` into training and test sets.
+
+  Args:
+    dataset: Gluon dataset instance.
+    test_ratio: (Optional, defaults to 0.1). The ratio of test samples.
+    shuffle: (Optional, defaults to True).
+      Whether to shuffle indices before splitting.
+    use_same_dataset_class: (Optional, defaults to True).
+      Whether to return instances of the same class as `dataset`. Otherwise,
+      return two `mxnet.gluon.data.ArrayDataset`s.
+
+  Returns:
+    Two disjoint Gluon datasets.
+
+  Examples:
+    >>> from mxnet.gluon.data import ArrayDataset
+    >>> from yamlchem.data.sets import ESOLDataset
+    >>> data = ArrayDataset(ESOLDataset())
+    >>> train_data, test_data = train_test_split(data)
+    >>> len(train_data) / len(data), len(test_data) / len(data)
+    (0.9, 0.1)
+  """
+  if use_same_dataset_class:
+    cls = dataset.__class__
+  else:
+    cls = ArrayDataset
+
+  n_samples = len(dataset)
+  n_train = math.floor((1 - test_ratio) * n_samples)
+
+  if not shuffle:
+    train_dataset = cls([dataset[i] for i in range(n_train)])
+    test_dataset = cls([dataset[i] for i in range(n_train, n_samples)])
+  else:
+    idx = array.array('L', list(range(n_samples)))
+    random.shuffle(idx)
+    train_dataset = cls([dataset[i] for i in idx[:n_train]])
+    test_dataset = cls([dataset[i] for i in idx[n_train:n_samples]])
+
+  return train_dataset, test_dataset
+
+
+def train_valid_test_split(
+    dataset,
+    valid_ratio: float = 0.1,
+    test_ratio: float = 0.1,
+    shuffle: bool = True,
+    use_same_dataset_class: bool = True,
+) -> Tuple[Dataset, ...]:
+  """Split `dataset` into training and test sets.
+
+  Args:
+    dataset: Gluon dataset instance.
+    valid_ratio: (Optional, defaults to 0.1). The ratio of validation samples.
+    test_ratio: (Optional, defaults to 0.1). The ratio of test samples.
+    shuffle: (Optional, defaults to True).
+      Whether to shuffle indices before splitting.
+    use_same_dataset_class: (Optional, defaults to True).
+      Whether to return instances of the same class as `dataset`. Otherwise,
+      return two `mxnet.gluon.data.ArrayDataset`s.
+
+  Returns:
+    Three disjoint Gluon datasets.
+
+  Examples:
+    >>> from mxnet.gluon.data import ArrayDataset
+    >>> from yamlchem.data.sets import ESOLDataset
+    >>> data = ArrayDataset(ESOLDataset())
+    >>> train_data, valid_data, test_data = train_valid_test_split(
+    ...     data, valid_ratio=0.2, test_ratio=0.1)
+    >>> n = len(data)
+    >>> len(train_data) / n, len(valid_data) / n, len(test_data) / n
+    (0.7, 0.2, 0.1)
+  """
+  train_dataset, test_dataset = train_test_split(
+      dataset, test_ratio, shuffle, use_same_dataset_class)
+  train_dataset, valid_dataset = train_test_split(
+      train_dataset, valid_ratio / (1 - test_ratio),
+      shuffle, use_same_dataset_class)
+  return train_dataset, valid_dataset, test_dataset
+
+
+class KFoldSplitter:
+  """K-fold cross-validation splitter.
+
+  Args:
+    n_folds: (Optional, defaults to 3). The number of cv blocks.
+
+  Examples:
+    >>> from mxnet.gluon.data import ArrayDataset
+    >>> data = ArrayDataset(list(range(6)))
+    >>> splitter = KFoldSplitter(n_folds=3)
+    >>> for train_data, valid_data in splitter.split(data):
+    ...     print(len(train_data), len(valid_data))
+    ...     print(list(train_data), list(valid_data))
+    4, 2
+    [2, 3, 4, 5], [0, 1]
+    4, 2
+    [0, 1, 4, 5], [2, 3]
+    4, 2
+    [0, 1, 2, 3], [4, 5]
+  """
+
+  def __init__(self, n_folds: int = 3):
+    self.n_folds = n_folds
+
+  def __repr__(self):
+    return f'{self.__class__.__name__}(n_folds={self.n_folds})'
+
+  def __eq__(self, other) -> bool:
+    return self.n_folds == other.n_folds
+
+  @property
+  def n_folds(self) -> int:
+    """The number of blocks.
+    """
+    return self.__n_folds
+
+  @n_folds.setter
+  def n_folds(self, n_folds: int):
+    """Set a new number of blocks.
+    """
+    if not isinstance(n_folds, int):
+      raise TypeError(f'`n_folds` must be int, not {type(n_folds)}')
+    if n_folds < 2:
+      raise ValueError(f'`n_folds` must be at least 2, not {n_folds}')
+    self.__n_folds = n_folds
+
+  @property
+  def training_ratio(self) -> float:
+    """The ratio of training samples.
+    """
+    return (self.n_folds - 1) / self.n_folds
+
+  @property
+  def validation_ratio(self) -> float:
+    """The ratio of validation samples.
+    """
+    return 1 / self.n_folds
+
+  def split(self, dataset: Dataset) \
+      -> Generator[Tuple[ArrayDataset, ArrayDataset], None, None]:
+    """Generate two disjoint datasets `self.n_folds` times.
+
+    Args:
+      dataset: Gluon-compatible dataset.
+
+    Yields:
+      Tuple of two mxnet.gluon.data.ArrayDataset instances.
+    """
+    for train_range, valid_range in self._get_idx(dataset):
+      yield (ArrayDataset([dataset[k] for k in train_range]),
+             ArrayDataset([dataset[k] for k in valid_range]))
+
+  def _get_idx(self, dataset: Dataset) \
+      -> Generator[Tuple[range, range], None, None]:
+    n_samples = len(dataset)
+    n_fold_samples = int(len(dataset) / self.n_folds)
+
+    for k in range(self.n_folds):
+      current_fold_i = k * n_fold_samples
+
+      valid_range = range(current_fold_i, current_fold_i + n_fold_samples)
+      train_range_l = range(min(valid_range.start, 0), valid_range.start)
+      train_range_r = range(valid_range.stop, max(valid_range.stop, n_samples))
+
+      yield itertools.chain(train_range_l, train_range_r), valid_range


### PR DESCRIPTION
Implement `yamlchem.data.splitter`:
* `train_test_split` - split Gluon-compatible dataset into two disjoint datasets. Optionally, shuffle the dataset.
* `train_valid_test_split` - same as `train_test_split` but into three datasets.
* `KFoldSplitter` - k-fold cross-validation splitter.
* `yamlchem.model.graph.train_gnn_predictor` accepts an optional validation data loader.